### PR TITLE
feat: add a new api to get supply delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The supply is calculated based on a combination of on-chain metrics and the off-
 | /cs                    | GET    | nil                | 24900001                             | return the circulating IP supply in whole number format | 
 | /ts                    | GET    | nil                | 9900001                              | return the total IP supply in whole number format   | 
 | /estimate-supply?date=2025-10-13       | GET    | date(format:yyyy-mm-dd) | {"result":"24900000.687"}            | return the estimated circulating IP supply at the given date in format yyyy-mm-dd|
+| /supplydelta?from=2025-10-13&to=2025-11-13 | GET    | from(format:yyyy-mm-dd), to(format:yyyy-mm-dd) | {"startTime":"2025-10-13","endTime":"2025-11-13","totalDelta":"12345.67","inflationDelta":"2345.67","vestingDelta":"10000.00"} | return the supply delta between two dates, including total delta, inflation delta and vesting delta |
 
 # Sources
 

--- a/api/http/http.go
+++ b/api/http/http.go
@@ -24,6 +24,10 @@ func StartHTTPServer() {
 
 	// estimate future circulating supply based on timestamp
 	r.GET("/estimate-supply", EstimateFutureCirculatingSupply)
+
+	// get supply delta between two timestamps
+	r.GET("/supplydelta", getSupplyDelta)
+
 	err := r.Run()
 	if err != nil {
 		panic(err)

--- a/api/http/supply.go
+++ b/api/http/supply.go
@@ -98,3 +98,52 @@ func EstimateFutureCirculatingSupply(c *gin.Context) {
 		"result": circulatingSupply.Text('f', 2),
 	})
 }
+
+func getSupplyDelta(c *gin.Context) {
+	startDate := c.Query("from")
+	endDate := c.Query("to")
+	layout := "2006-01-02"
+	startTime, err := time.ParseInLocation(layout, startDate, time.UTC)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid start date format, must be YYYY-MM-DD",
+		})
+		return
+	}
+	endTime, err := time.ParseInLocation(layout, endDate, time.UTC)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid end date format, must be YYYY-MM-DD",
+		})
+		return
+	}
+	if endTime.Before(startTime) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "end date must be after start date",
+		})
+		return
+	}
+
+	// TODO: remove this check when historical data is available
+	// start time is yyyy-mm-dd, check if start time is in the current day, if in current day but before current timestamp, use start time. if start time is before current day, return error
+	isCurDay := startTime.Year() == time.Now().UTC().Year() && startTime.YearDay() == time.Now().UTC().YearDay()
+	if startTime.Before(time.Now().UTC()) && !isCurDay {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "start date must not be in the past",
+		})
+		return
+	}
+
+	supplyDelta, err := service.GetSupplyDelta(startTime.Unix(), endTime.Unix())
+	if err != nil {
+		log.Error("Error getting supply delta", "error", err)
+		c.JSON(500, gin.H{
+			"error": "internal server error",
+		})
+		return
+	}
+
+	c.JSON(200, gin.H{
+		"result": supplyDelta,
+	})
+}

--- a/service/supply.go
+++ b/service/supply.go
@@ -252,3 +252,76 @@ func EstimateFutureCirculatingSupply(timestamp int64) (*big.Float, error) {
 	futureCirculatingSupply.Add(futureCirculatingSupply, futureMint)
 	return futureCirculatingSupply, nil
 }
+
+type SupplyDelta struct {
+	StartTime      string `json:"start_time"`
+	EndTime        string `json:"end_time"`
+	TotalDelta     string `json:"total_delta"`
+	InflationDelta string `json:"inflation_delta"`
+	VestingDelta   string `json:"vesting_delta"`
+}
+
+// totalSupplyDelta = inflationDelta + vestingDelta
+// inflationDelta = minted - burnt
+func GetSupplyDelta(startTime, endTime int64) (*SupplyDelta, error) {
+	var inflationDelta, vestingDelta *big.Float
+	var err error
+
+	inflationDelta, err = getInflationDelta(startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	vestingDelta, err = getVestingDelta(startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	totalSupplyDelta := new(big.Float).Set(inflationDelta)
+	totalSupplyDelta.Add(totalSupplyDelta, vestingDelta)
+
+	return &SupplyDelta{
+		StartTime:      time.Unix(startTime, 0).Format(time.DateOnly),
+		EndTime:        time.Unix(endTime, 0).Format(time.DateOnly),
+		TotalDelta:     totalSupplyDelta.Text('f', 2),
+		InflationDelta: inflationDelta.Text('f', 2),
+		VestingDelta:   vestingDelta.Text('f', 2),
+	}, nil
+}
+
+// inflationDelta = mintPerSec * (endTime - startTime) - burntDelta
+func getInflationDelta(startTime, endTime int64) (*big.Float, error) {
+	// calculate minted amount
+	blockTimeLock.RLock()
+	seconds := endTime - startTime
+	inflationDelta := new(big.Float).Mul(new(big.Float).SetFloat64(mintPerSec), new(big.Float).SetInt64(seconds))
+	blockTimeLock.RUnlock()
+
+	// calculate burnt amount
+	burntDelta, err := getBurntDelta(startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+	inflationDelta.Sub(inflationDelta, burntDelta)
+	return inflationDelta, nil
+}
+
+func getVestingDelta(startTime, endTime int64) (*big.Float, error) {
+	startVestedSupply, err := GetVestedSupply(big.NewInt(startTime))
+	if err != nil {
+		return nil, err
+	}
+	endVestedSupply, err := GetVestedSupply(big.NewInt(endTime))
+	if err != nil {
+		return nil, err
+	}
+	vestingDelta := new(big.Float).Sub(endVestedSupply, startVestedSupply)
+	return vestingDelta, nil
+}
+
+func getBurntDelta(startTime, endTime int64) (*big.Float, error) {
+	// Ignore burnt delta for now, reasons:
+	// 1. burnt amount is very small compared to total supply
+	// 2. now this is for future estimation only, if this is for historical analysis, we need to store the burnt amount for each day
+	return big.NewFloat(0), nil
+}

--- a/service/supply_test.go
+++ b/service/supply_test.go
@@ -4,6 +4,7 @@ import (
 	"circulation-supply-api/config"
 	"math/big"
 	"testing"
+	"time"
 )
 
 func setConf() {
@@ -11,7 +12,22 @@ func setConf() {
 		VestingStartYear:  2025,
 		VestingStartMonth: 2,
 		VestingStartDay:   13,
+		Vesting: []float64{
+			250000000, 256952083, 263904167, 270856250, 277808333, 284760417,
+			291712500, 298664581, 305616664, 312568747, 319520830, 326472913,
+			427499996, 445655899, 463811802, 481967705, 500123608, 518279512,
+			536435415, 554591318, 572747221, 590903124, 609059027, 627214930,
+			645370833, 663526736, 681682640, 699838543, 717994446, 736150349,
+			754306252, 772462155, 790618058, 808773961, 826929864, 845085767,
+			863241670, 874638198, 886034725, 897431253, 908827780, 920224308,
+			931620836, 943017363, 954413891, 965810418, 977206946, 988603473,
+			1000000000,
+		},
 	}
+	mintPerSec, _ = new(big.Float).SetPrec(64).Quo(
+		new(big.Float).SetFloat64(BlockReward),
+		new(big.Float).SetFloat64(2.364),
+	).Float64()
 }
 
 func TestMonthsPassedSinceGenesis(t *testing.T) {
@@ -41,4 +57,50 @@ func TestMonthsPassedSinceGenesis(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSupplyDelta(t *testing.T) {
+	setConf()
+
+	expectedDelta := &SupplyDelta{
+		StartTime:      "2026-01-13",
+		EndTime:        "2026-02-13",
+		InflationDelta: new(big.Float).Mul(new(big.Float).SetFloat64(mintPerSec), new(big.Float).SetInt64(31*24*3600)).Text('f', 2),
+		VestingDelta:   new(big.Float).SetFloat64(427499996-326472913).Text('f', 2),
+	}
+
+	tests := []struct {
+		startTimestamp int64
+		endTimestamp   int64
+		expectedDelta  *SupplyDelta
+	}{
+		{startTimestamp: timeStringToTimestamp("2026-01-13"), endTimestamp: timeStringToTimestamp("2026-02-13"), expectedDelta: expectedDelta},
+	}
+
+	for _, tt := range tests {
+		t.Run("test", func(t *testing.T) {
+			r, err := GetSupplyDelta(tt.startTimestamp, tt.endTimestamp)
+			if err != nil {
+				t.Error("GetSupplyDelta() error =", err)
+			}
+			if r.StartTime != tt.expectedDelta.StartTime {
+				t.Errorf("GetSupplyDelta() StartTime = %v; want %v", r.StartTime, tt.expectedDelta.StartTime)
+			}
+			if r.EndTime != tt.expectedDelta.EndTime {
+				t.Errorf("GetSupplyDelta() EndTime = %v; want %v", r.EndTime, tt.expectedDelta.EndTime)
+			}
+			if r.InflationDelta != tt.expectedDelta.InflationDelta {
+				t.Errorf("GetSupplyDelta() InflationDelta = %v; want %v", r.InflationDelta, tt.expectedDelta.InflationDelta)
+			}
+			if r.VestingDelta != tt.expectedDelta.VestingDelta {
+				t.Errorf("GetSupplyDelta() VestingDelta = %v; want %v", r.VestingDelta, tt.expectedDelta.VestingDelta)
+			}
+		})
+	}
+}
+
+func timeStringToTimestamp(t string) int64 {
+	layout := "2006-01-02"
+	tm, _ := time.ParseInLocation(layout, t, time.UTC)
+	return tm.Unix()
 }


### PR DESCRIPTION
## Add a new /supply-delta API to query token supply changes between two dates.

| Entrypoint            | Action | Request parameters | Response example                     | Comment                                             | 
|------------------------|--------|--------------------|--------------------------------------|-----------------------------------------------------|
| /supply-delta?from=2025-10-13&to=2025-11-13 | GET    | from(format:yyyy-mm-dd), to(format:yyyy-mm-dd) | {"startTime":"2025-10-13","endTime":"2025-11-13","totalDelta":"12345.67","inflationDelta":"2345.67","vestingDelta":"10000.00"} | return the supply delta between two dates, including total delta, inflation delta and vesting delta |

Note:
- totalDelta = inflationDelta + vestingDelta
- inflationDelta currently excludes burnt tokens since the burnt amount is negligible.
- The `from` parameter refers to a future date; querying deltas for past dates would require additional historical data storage and it's not supported for now.