### PR TITLE
query history total supply

### DIFF
--- a/api/http/http.go
+++ b/api/http/http.go
@@ -28,6 +28,9 @@ func StartHTTPServer() {
 	// get supply delta between two timestamps
 	r.GET("/supplydelta", getSupplyDelta)
 
+	// get historical total supply data
+	r.GET("/history/total-supply", getHistoryTotalSupply)
+
 	err := r.Run()
 	if err != nil {
 		panic(err)

--- a/api/http/supply.go
+++ b/api/http/supply.go
@@ -1,9 +1,12 @@
 package http
 
 import (
+	"circulation-supply-api/dao"
 	"circulation-supply-api/metrics"
 	"circulation-supply-api/service"
+	"errors"
 	log "log/slog"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -145,5 +148,45 @@ func getSupplyDelta(c *gin.Context) {
 
 	c.JSON(200, gin.H{
 		"result": supplyDelta,
+	})
+}
+
+func getHistoryTotalSupply(c *gin.Context) {
+	blockStr := c.Query("block")
+	blockNumber, ok := new(big.Int).SetString(blockStr, 10)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid block number",
+		})
+		return
+	}
+
+	totalSupply, err := service.GetHistoryTotalSupply(blockNumber.Uint64())
+	if err != nil {
+		if errors.Is(err, dao.ErrRecordNotFound) {
+			oldestBlock, latestBlock, err := service.GetHistoryRange()
+			if err != nil {
+				log.Error("Error getting history range", "error", err)
+				c.JSON(500, gin.H{
+					"error": "internal server error",
+				})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"result":         "syncing",
+				"available_from": oldestBlock,
+				"available_to":   latestBlock,
+			})
+			return
+		}
+		log.Error("Error getting history total supply", "error", err)
+		c.JSON(500, gin.H{
+			"error": "internal server error",
+		})
+		return
+	}
+
+	c.JSON(200, gin.H{
+		"result": totalSupply.Text('f', 2),
 	})
 }

--- a/dao/fee.go
+++ b/dao/fee.go
@@ -1,11 +1,24 @@
 package dao
 
+import "gorm.io/gorm"
+
+var ErrRecordNotFound = gorm.ErrRecordNotFound
+
 type AccumulatedFees struct {
 	ID                uint
 	BlockNumber       uint64
 	TotalBurntBaseFee string
 	TotalStakeReward  string
 	TotalStakedToken  string
+}
+
+type HistoryAccumulatedFees struct {
+	ID                uint
+	BlockNumber       uint64
+	TotalBurntBaseFee string
+	TotalStakeReward  string
+	TotalStakedToken  string
+	BlockTimestamp    uint64
 }
 
 type BackwardsStakedToken struct {
@@ -42,4 +55,26 @@ func GetBackwardsStakedToken() (uint64, string, error) {
 	var f BackwardsStakedToken
 	err := db.Table("public.backwards_staked_token").First(&f).Error
 	return f.BlockNumber, f.Amount, err
+}
+
+func BatchAddHistoryAccumulatedFees(fees []HistoryAccumulatedFees) error {
+	return db.Table("public.history_accumulated_fees").Create(&fees).Error
+}
+
+func GetOldestHistoryAccumulatedFees() (*HistoryAccumulatedFees, error) {
+	var f HistoryAccumulatedFees
+	err := db.Table("public.history_accumulated_fees").Order("block_number asc").First(&f).Error
+	return &f, err
+}
+
+func GetLatestHistoryAccumulatedFees() (*HistoryAccumulatedFees, error) {
+	var f HistoryAccumulatedFees
+	err := db.Table("public.history_accumulated_fees").Order("block_number desc").First(&f).Error
+	return &f, err
+}
+
+func GetHistoryAccumulatedFeesByBlockNumber(blockNumber uint64) (*HistoryAccumulatedFees, error) {
+	var f HistoryAccumulatedFees
+	err := db.Table("public.history_accumulated_fees").Where("block_number = ?", blockNumber).First(&f).Error
+	return &f, err
 }

--- a/service/backwardsScan.go
+++ b/service/backwardsScan.go
@@ -18,6 +18,7 @@ var (
 	BackwardsStakedToken *big.Float
 )
 
+// Deprecated
 // Iterate from current block/last block to a configurable block number
 func BackwardsScanTrace() {
 	// short circuit to disable backwards scan

--- a/service/fee.go
+++ b/service/fee.go
@@ -13,6 +13,10 @@ func saveAccumulatedFees(block uint64, totalBurntBaseFee *big.Float, totalStakeR
 	return dao.SaveAccumulatedFees(block, totalBurntBaseFee.Text('f', -1), totalStakeReward.Text('f', -1), totalStakedToken.Text('f', -1))
 }
 
+func BatchAddHistoryAccumulatedFees(fees []dao.HistoryAccumulatedFees) error {
+	return dao.BatchAddHistoryAccumulatedFees(fees)
+}
+
 // load retrieves the latest accumulated fees from the database.
 func load() (uint64, *big.Float, *big.Float, *big.Float, error) {
 	fee, err := dao.GetLatestAccumulatedFees()
@@ -38,4 +42,8 @@ func load() (uint64, *big.Float, *big.Float, *big.Float, error) {
 		return 0, totalBurntBaseFee, totalStakeReward, big.NewFloat(0).SetPrec(64), fmt.Errorf("error parsing total staked token")
 	}
 	return fee.BlockNumber + 1, totalBurntBaseFee, totalStakeReward, totalStakedToken, nil
+}
+
+func GetOldestAccumulatedFees() (*dao.HistoryAccumulatedFees, error) {
+	return dao.GetOldestHistoryAccumulatedFees()
 }

--- a/service/scan.go
+++ b/service/scan.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"circulation-supply-api/dao"
 	"circulation-supply-api/metrics"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -24,6 +26,18 @@ var (
 	traceEventCh = make(chan *Trace, 100)
 )
 
+var accumulatedFeesBatch = []dao.HistoryAccumulatedFees{}
+
+var (
+	firstBlockBackwards        int64 = 0
+	totalBurntBaseFeeBackwards       = big.NewFloat(0).SetPrec(64)
+	totalStakeRewardBackwards        = big.NewFloat(0).SetPrec(64)
+	totalStakedTokenBackwards        = big.NewFloat(0).SetPrec(64)
+
+	// should init from history_accumulated_fees while no records found in history_accumulated_fees
+	initHistory = false
+)
+
 // Start starts the main loop
 func Start() {
 	var err error
@@ -34,8 +48,29 @@ func Start() {
 	}
 	metrics.CurrentlyIndexed.Set(float64(currentBlock))
 
-	// backwards scan is disabled on Mainnet
-	go BackwardsScanTrace()
+	oldestFees, err := GetOldestAccumulatedFees()
+	if err != nil {
+		if errors.Is(err, dao.ErrRecordNotFound) {
+			initHistory = true
+		} else {
+			log.Warn("Error fetching oldest accumulated fees", "error", err)
+			return
+		}
+	}
+	if initHistory {
+		firstBlockBackwards = int64(currentBlock) - 1
+		totalBurntBaseFeeBackwards.Set(totalBurntBaseFee)
+		totalStakeRewardBackwards.Set(totalStakeReward)
+		totalStakedTokenBackwards.Set(totalStakedToken)
+	} else {
+		firstBlockBackwards = int64(oldestFees.BlockNumber)
+		totalBurntBaseFeeBackwards, _ = new(big.Float).SetString(oldestFees.TotalBurntBaseFee)
+		totalStakeRewardBackwards, _ = new(big.Float).SetString(oldestFees.TotalStakeReward)
+		totalStakedTokenBackwards, _ = new(big.Float).SetString(oldestFees.TotalStakedToken)
+	}
+
+	// get burnt fees from first block of current round to a configurable block number backwards
+	go startBackwardsScan(firstBlockBackwards)
 
 	// forwards scan
 	go watchBlocks()
@@ -80,6 +115,9 @@ func watchBlocks() {
 // and saves the accumulated fees every 100 blocks
 func handleBlock() {
 	for block := range blockEventCh {
+		blockNumber, _ := new(big.Int).SetString(block.Number, 0)
+		curBlock := blockNumber.Uint64()
+
 		burntIP := calculateBurntIP(block.BaseFeePerGas, block.GasUsed)
 		stakeReward := calculateStakeReward(block.Withdrawals)
 
@@ -90,14 +128,108 @@ func handleBlock() {
 		totalStakeReward.Add(totalStakeReward, stakeReward)
 		totalStakedToken.Add(totalStakedToken, stakedToken)
 
-		if currentBlock > 0 && currentBlock%100 == 0 {
-			err := saveAccumulatedFees(currentBlock, totalBurntBaseFee, totalStakeReward, totalStakedToken)
+		blockTimestamp, _ := new(big.Int).SetString(block.Time, 0)
+		accumulatedFeesBatch = append(accumulatedFeesBatch, dao.HistoryAccumulatedFees{
+			BlockNumber:       curBlock,
+			TotalBurntBaseFee: totalBurntBaseFee.Text('f', -1),
+			TotalStakeReward:  totalStakeReward.Text('f', -1),
+			TotalStakedToken:  totalStakedToken.Text('f', -1),
+			BlockTimestamp:    blockTimestamp.Uint64(),
+		})
+
+		if curBlock > 0 && curBlock%100 == 0 {
+			err := saveAccumulatedFees(curBlock, totalBurntBaseFee, totalStakeReward, totalStakedToken)
 			if err != nil {
 				log.Error("Error saving data", "error", err)
 			}
-			log.Info("[Forwards] BlockNumber", "number", currentBlock, "burntBaseFee", burntIP.Text('f', -1), "totalBurntBaseFee", totalBurntBaseFee.Text('f', -1), "stakeReward", stakeReward.Text('f', -1), "totalStake", totalStakeReward.Text('f', -1), "totalStakedToken", totalStakedToken.Text('f', -1))
+			log.Info("[Forwards] BlockNumber", "number", curBlock, "burntBaseFee", burntIP.Text('f', -1), "totalBurntBaseFee", totalBurntBaseFee.Text('f', -1), "stakeReward", stakeReward.Text('f', -1), "totalStake", totalStakeReward.Text('f', -1), "totalStakedToken", totalStakedToken.Text('f', -1))
+
+			err = BatchAddHistoryAccumulatedFees(accumulatedFeesBatch)
+			if err != nil {
+				log.Error("Error batch saving accumulated fees", "error", err)
+			}
+			log.Info("[Forwards] batch saved accumulated fees up from block", "block", accumulatedFeesBatch[0].BlockNumber, "to", accumulatedFeesBatch[len(accumulatedFeesBatch)-1].BlockNumber)
+			accumulatedFeesBatch = []dao.HistoryAccumulatedFees{}
 		}
-		metrics.CurrentlyIndexed.Set(float64(currentBlock))
+		metrics.CurrentlyIndexed.Set(float64(curBlock))
+
+	}
+}
+
+func startBackwardsScan(startBlock int64) {
+	curBlock := startBlock - 1
+	batch := []dao.HistoryAccumulatedFees{}
+
+	// Add first block to batch
+	if initHistory {
+		block, err := getBlockByNumber(fmt.Sprintf("0x%x", startBlock))
+		if err != nil {
+			log.Error("Error fetching block", "error", err)
+			return
+		}
+		if block == nil {
+			log.Error("First block for backwards scan is nil", "block", startBlock)
+			return
+		}
+		blockTimestamp, _ := new(big.Int).SetString(block.Time, 0)
+		batch = append(batch, dao.HistoryAccumulatedFees{
+			BlockNumber:       uint64(startBlock),
+			TotalBurntBaseFee: totalBurntBaseFeeBackwards.Text('f', -1),
+			TotalStakeReward:  totalStakeRewardBackwards.Text('f', -1),
+			TotalStakedToken:  totalStakedTokenBackwards.Text('f', -1),
+			BlockTimestamp:    blockTimestamp.Uint64(),
+		})
+		initHistory = false
+	}
+
+	for curBlock > 0 {
+		block, err := getBlockByNumber(fmt.Sprintf("0x%x", curBlock))
+		if err != nil {
+			log.Error("Error fetching block", "error", err)
+			time.Sleep(time.Second * 5)
+			continue
+		}
+		if block == nil {
+			time.Sleep(time.Second * 5)
+			continue
+		}
+		burntIP := calculateBurntIP(block.BaseFeePerGas, block.GasUsed)
+
+		trace, err := FetchTraces(fmt.Sprintf("0x%x", curBlock))
+		if err != nil {
+			log.Error("Error fetching traces", "error", err)
+			time.Sleep(time.Second * 5)
+			continue
+		}
+		if trace == nil {
+			time.Sleep(time.Second * 5)
+			continue
+		}
+		stakedToken := ProcessTraces(trace)
+
+		totalBurntBaseFeeBackwards.Sub(totalBurntBaseFeeBackwards, burntIP)
+		totalStakeRewardBackwards.Sub(totalStakeRewardBackwards, calculateStakeReward(block.Withdrawals))
+		totalStakedTokenBackwards.Sub(totalStakedTokenBackwards, stakedToken)
+
+		blockTimestamp, _ := new(big.Int).SetString(block.Time, 0)
+		batch = append(batch, dao.HistoryAccumulatedFees{
+			BlockNumber:       uint64(curBlock),
+			TotalBurntBaseFee: totalBurntBaseFeeBackwards.Text('f', -1),
+			TotalStakeReward:  totalStakeRewardBackwards.Text('f', -1),
+			TotalStakedToken:  totalStakedTokenBackwards.Text('f', -1),
+			BlockTimestamp:    blockTimestamp.Uint64(),
+		})
+		curBlock--
+
+		if len(batch) >= 100 || curBlock == 0 {
+			err = BatchAddHistoryAccumulatedFees(batch)
+			if err != nil {
+				log.Error("Error batch saving accumulated fees backwards", "error", err)
+				break
+			}
+			log.Info("[Backwards] batch saved accumulated fees up from block", "block", batch[0].BlockNumber, "to", batch[len(batch)-1].BlockNumber)
+			batch = []dao.HistoryAccumulatedFees{}
+		}
 	}
 }
 

--- a/service/supply.go
+++ b/service/supply.go
@@ -325,3 +325,64 @@ func getBurntDelta(startTime, endTime int64) (*big.Float, error) {
 	// 2. now this is for future estimation only, if this is for historical analysis, we need to store the burnt amount for each day
 	return big.NewFloat(0), nil
 }
+
+// GetHistoryTotalSupply retrieves the total supply at a specific block number.
+func GetHistoryTotalSupply(blockNumber uint64) (*big.Float, error) {
+	var fee *dao.HistoryAccumulatedFees
+	var b bool
+	var err error
+
+	fee, err = dao.GetHistoryAccumulatedFeesByBlockNumber(blockNumber)
+	if err != nil || fee == nil {
+		log.Error("Failed to get latest accumulated fees", "error", err)
+		return nil, err
+	}
+	totalBurntBaseFee, b = new(big.Float).SetString(fee.TotalBurntBaseFee)
+	if !b {
+		err = fmt.Errorf("error parsing total burnt base fee")
+		return nil, err
+	}
+	totalStakeReward, b = new(big.Float).SetString(fee.TotalStakeReward)
+	if !b {
+		err = fmt.Errorf("error parsing total stake reward")
+		return nil, err
+	}
+	totalStakedToken, b := new(big.Float).SetString(fee.TotalStakedToken)
+	if !b {
+		err = fmt.Errorf("error parsing total staked token")
+		return nil, err
+	}
+
+	totalBalance := big.NewInt(0)
+	for _, zeroAddress := range config.Conf.ZeroAddresses {
+		var balance *big.Int
+		balance, err = getBalanceAtBlock(zeroAddress, blockNumber)
+		if err != nil {
+			log.Error("Failed to get zero address balance", "address", zeroAddress, "error", err)
+			return nil, err
+		}
+		totalBalance.Add(totalBalance, balance)
+	}
+	ipSentToZeroAddress := new(big.Float).Quo(new(big.Float).SetInt(totalBalance), big.NewFloat(1e18))
+
+	totalSupply := big.NewFloat(config.Conf.GenesisTotalSupply).SetPrec(64)
+	totalSupply.Sub(totalSupply, totalBurntBaseFee)
+	totalSupply.Sub(totalSupply, ipSentToZeroAddress)
+	totalSupply.Add(totalSupply, totalStakeReward)
+	// ipSentToZeroAddress contains totalStakedToken, so we need to add it back
+	totalSupply.Add(totalSupply, totalStakedToken)
+
+	return totalSupply, nil
+}
+
+func GetHistoryRange() (uint64, uint64, error) {
+	oldest, err := dao.GetOldestHistoryAccumulatedFees()
+	if err != nil {
+		return 0, 0, err
+	}
+	latest, err := dao.GetLatestHistoryAccumulatedFees()
+	if err != nil {
+		return 0, 0, err
+	}
+	return oldest.BlockNumber, latest.BlockNumber, nil
+}

--- a/sql/update_1.sql
+++ b/sql/update_1.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS history_accumulated_fees (
+    id                BIGSERIAL PRIMARY KEY,
+    block_number            BIGINT NOT NULL,
+    total_burnt_base_fee VARCHAR(64) NOT NULL,
+    total_stake_reward  VARCHAR(64) NOT NULL,
+    total_staked_token VARCHAR(64) NOT NULL,
+    block_timestamp BIGINT NOT NULL
+);
+
+
+CREATE INDEX IF NOT EXISTS idx_history_accumulated_fees_block_number
+    ON history_accumulated_fees (block_number);
+
+CREATE INDEX IF NOT EXISTS idx_history_accumulated_fees_block_timestamp
+    ON history_accumulated_fees (block_timestamp);


### PR DESCRIPTION
## Add a new API to query historical total supply.

| Entrypoint            | Action | Request parameters | Response example                     | Comment                                             | 
|------------------------|--------|--------------------|--------------------------------------|-----------------------------------------------------|
| /history/total-supply?block=10000 | GET    | block | {"result":"1014417904.60"} | return the total supply by block |

Note:
- It takes time to index blocks backwards to genesis. If the block has not been indexed, /history/total-supply will return `syncing` and the queryable range. 