### PR TITLE
Added Docker image build and push workflows for ECR

### DIFF
--- a/.github/workflows/aws-api-cd.yml
+++ b/.github/workflows/aws-api-cd.yml
@@ -34,7 +34,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           APP_NAME: ${{ needs.define-params.outputs.app_name }}
         run: |
-          docker build -f ./dockerfiles/scanner.Dockerfile -t $REGISTRY/$APP_NAME:${{ github.sha }} .
+          docker build -f ./dockerfiles/api.Dockerfile -t $REGISTRY/$APP_NAME:${{ github.sha }} .
           docker push $REGISTRY/$APP_NAME:${{ github.sha }}
 
   update-helm-tag:

--- a/.github/workflows/aws-api-cd.yml
+++ b/.github/workflows/aws-api-cd.yml
@@ -43,4 +43,5 @@ jobs:
       app_name: ${{ needs.define-params.outputs.app_name }}
       helm_file_path: "story-helm/circulation-supply/circulation-supply-api/use1-stage.yaml"
       image_tag: ${{ needs.define-params.outputs.image_tag }}
-    secrets: inherit
+    secrets:
+      helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}

--- a/.github/workflows/aws-api-cd.yml
+++ b/.github/workflows/aws-api-cd.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Build and push
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          APP_NAME: ${{ needs.define-params.outputs.app_name }}
         run: |
-          docker build -f ./dockerfiles/api.Dockerfile -t $REGISTRY/circulation-supply-api:${{ github.sha }} .
-          docker push $REGISTRY/circulation-supply-api:${{ github.sha }}
+          docker build -f ./dockerfiles/scanner.Dockerfile -t $REGISTRY/$APP_NAME:${{ github.sha }} .
+          docker push $REGISTRY/$APP_NAME:${{ github.sha }}
 
   update-helm-tag:
     needs: [define-params, ecr-image-build]

--- a/.github/workflows/aws-api-cd.yml
+++ b/.github/workflows/aws-api-cd.yml
@@ -1,0 +1,46 @@
+name: Build and Push API Image.
+
+on:
+  push:
+    branches:
+      - 'staging'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  define-params:
+    runs-on: ubuntu-latest
+    outputs:
+      app_name: circulation-supply-api
+      image_tag: ${{ github.sha }}
+    steps:
+      - run: echo "Exposing params"
+
+  ecr-image-build:
+    runs-on: ubuntu-latest
+    needs: [define-params]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_GITHUB_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -f ./dockerfiles/api.Dockerfile -t $REGISTRY/circulation-supply-api:${{ github.sha }} .
+          docker push $REGISTRY/circulation-supply-api:${{ github.sha }}
+
+  update-helm-tag:
+    needs: [define-params, ecr-image-build]
+    uses: ./.github/workflows/aws-reusable-helm-tag-update.yml
+    with:
+      app_name: ${{ needs.define-params.outputs.app_name }}
+      helm_file_path: "story-helm/circulation-supply/circulation-supply-api/use1-stage.yaml"
+      image_tag: ${{ needs.define-params.outputs.image_tag }}
+    secrets: inherit

--- a/.github/workflows/aws-reusable-helm-tag-update.yml
+++ b/.github/workflows/aws-reusable-helm-tag-update.yml
@@ -15,6 +15,14 @@ on:
         description: "The new image tag to set"
         required: true
         type: string
+    secrets:
+      helm_repo_token:
+        description: "GitHub token with access to the story-helm repository"
+        required: true
+
+permissions:
+  contents: read
+
 jobs:
   update-helm-tag:
     runs-on: ubuntu-latest
@@ -24,10 +32,10 @@ jobs:
         with:
           repository: storyprotocol/story-helm
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.helm_repo_token }}
 
       - name: Update image tag
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.52.5
         with:
           cmd: yq -i '.image.tag = "${{ inputs.image_tag }}"' '${{ inputs.helm_file_path }}'
 

--- a/.github/workflows/aws-reusable-helm-tag-update.yml
+++ b/.github/workflows/aws-reusable-helm-tag-update.yml
@@ -1,0 +1,44 @@
+name: "Update Helm Image Tag"
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "Name of the application"
+        required: true
+        type: string
+      helm_file_path:
+        description: "Path to the Helm values file in story-helm repo (e.g. story/story-api/use1-stage.yaml)"
+        required: true
+        type: string
+      image_tag:
+        description: "The new image tag to set"
+        required: true
+        type: string
+jobs:
+  update-helm-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout story-helm repository
+        uses: actions/checkout@v4
+        with:
+          repository: storyprotocol/story-helm
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update image tag
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = "${{ inputs.image_tag }}"' '${{ inputs.helm_file_path }}'
+
+      - name: Commit and push
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git fetch && git checkout main
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Nothing to commit, working directory clean"
+          else
+            git commit -am "${{ inputs.app_name }}: Update image tag to ${{ inputs.image_tag }}"
+            git push
+          fi

--- a/.github/workflows/aws-scanner-cd.yml
+++ b/.github/workflows/aws-scanner-cd.yml
@@ -1,0 +1,46 @@
+name: Build and Push Scanner Image.
+
+on:
+  push:
+    branches:
+      - 'staging'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  define-params:
+    runs-on: ubuntu-latest
+    outputs:
+      app_name: circulation-supply-scanner
+      image_tag: ${{ github.sha }}
+    steps:
+      - run: echo "Exposing params"
+
+  ecr-image-build:
+    runs-on: ubuntu-latest
+    needs: [define-params]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_PUSH_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -f ./dockerfiles/scanner.Dockerfile -t $REGISTRY/circulation-supply-scanner:${{ github.sha }} .
+          docker push $REGISTRY/circulation-supply-scanner:${{ github.sha }}
+
+  update-helm-tag:
+    needs: [define-params, ecr-image-build]
+    uses: ./.github/workflows/aws-reusable-helm-tag-update.yml
+    with:
+      app_name: ${{ needs.define-params.outputs.app_name }}
+      helm_file_path: "story-helm/circulation-supply/circulation-supply-scanner/use1-stage.yaml"
+      image_tag: ${{ needs.define-params.outputs.image_tag }}
+    secrets: inherit

--- a/.github/workflows/aws-scanner-cd.yml
+++ b/.github/workflows/aws-scanner-cd.yml
@@ -43,4 +43,5 @@ jobs:
       app_name: ${{ needs.define-params.outputs.app_name }}
       helm_file_path: "story-helm/circulation-supply/circulation-supply-scanner/use1-stage.yaml"
       image_tag: ${{ needs.define-params.outputs.image_tag }}
-    secrets: inherit
+    secrets:
+      helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}

--- a/.github/workflows/aws-scanner-cd.yml
+++ b/.github/workflows/aws-scanner-cd.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Build and push
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          APP_NAME: ${{ needs.define-params.outputs.app_name }}
         run: |
-          docker build -f ./dockerfiles/scanner.Dockerfile -t $REGISTRY/circulation-supply-scanner:${{ github.sha }} .
-          docker push $REGISTRY/circulation-supply-scanner:${{ github.sha }}
+          docker build -f ./dockerfiles/scanner.Dockerfile -t $REGISTRY/$APP_NAME:${{ github.sha }} .
+          docker push $REGISTRY/$APP_NAME:${{ github.sha }}
 
   update-helm-tag:
     needs: [define-params, ecr-image-build]


### PR DESCRIPTION
Added 3 GitHub workflows:
- aws-api-cd
- aws-scanner-cd
- aws-reusable-helm-tag-update
The aws-reusable-helm-tag-update.yml workflow should be moved to the gha-workflows repository so it can be reused across all workflows.